### PR TITLE
Adapting LM_scoring.py, PPL differs from tensorboard

### DIFF
--- a/eole/bin/tools/LM_scoring.py
+++ b/eole/bin/tools/LM_scoring.py
@@ -8,12 +8,13 @@ from eole.utils.logging import init_logger, logger
 from eole.inputters.dynamic_iterator import build_dynamic_dataset_iter
 from eole.utils.loss import LossCompute
 from eole.constants import DefaultTokens, CorpusTask
-from eole.transforms import get_transforms_cls
+from eole.transforms import get_transforms_cls, make_transforms
+from eole.models.model import BaseModel
+from eole.decoders.ensemble import load_test_model as ensemble_load_test_model
 
 from argparse import ArgumentParser
 from eole.bin import BaseBin, register_bin
 from eole.config.cli import add_model
-from eole.config import get_non_default_values
 from eole.config.run import PredictConfig
 
 """
@@ -21,18 +22,16 @@ This script scores all sentences of a file using dynamic data.
 For this purpose we use the same pipeline as the validation of a file
 Below is an example of settings of a config.yaml file
 
-model: lm-de.news2021_step_100000.pt
-src: newstest2014-ref.de
-tgt: newstest2014-ref.de
-transforms: [onmt_tokenize]
-batch_size: 16
-gpu: 0
-src_subword_type: bpe
-src_subword_model: subwords.en_de.bpe
-src_eoletok_kwargs: '{"mode": "aggressive"}'
-tgt_subword_type: bpe
-tgt_subword_model: subwords.en_de.bpe
-tgt_eoletok_kwargs: '{"mode": "aggressive"}'
+verbose: false
+n_best: 3
+top_p: 0.9
+beam_size: 10
+world_size: 1
+gpu_ranks: [0]
+# use symlinks to last saved step
+model_path: data/wikitext/wikitext-103-raw-v1/run/model-lm
+src: data/wikitext/wikitext-103-raw-v1/lm_input.txt
+output: data/wikitext/wikitext-103-raw-v1/lm_pred.txt
 
 Output is the data and tab separated score
 use the -output setting for preds + scores
@@ -49,8 +48,7 @@ class LMScoring(BaseBin):
             "--config",
             "-c",
             required=False,
-            help="Path of main YAML config file.",
-        )
+            help="Path of main YAML config file.")
 
     @classmethod
     def run(cls, args):
@@ -62,9 +60,6 @@ class LMScoring(BaseBin):
             config = {}
         _parser = ArgumentParser()
         add_model(_parser, PredictConfig)
-        defaults = vars(_parser.parse_args([]))
-        stuff_to_update = get_non_default_values(args, defaults)
-        config.update(stuff_to_update)
         config = PredictConfig(**config)
         init_logger(config.log_file)
         set_random_seed(config.seed, False)
@@ -75,26 +70,28 @@ class LMScoring(BaseBin):
         if len(config.gpu_ranks) > 1:
             logger.warning(f"gpu_ranks is {str(config.gpu_ranks)} but only the first one will be used.")
 
-        vocabs, model, model_opt = config.model.model_class.load_test_model(config)
+        load_test_model = ensemble_load_test_model if len(config.model_path) > 1 else BaseModel.load_test_model
+        vocabs, model, model_opt = load_test_model(config, 0)
         pad_token = vocabs["specials"].get("pad_token", DefaultTokens.PAD)
-        padding_idx = vocabs["tgt"][pad_token]
+        padding_idx = vocabs["tgt"].tokens_to_ids[pad_token]
         criterion = torch.nn.CrossEntropyLoss(ignore_index=padding_idx, reduction="none")
         valid_loss = LossCompute(
             criterion,
             model.generator,
             tgt_shift_index=0,
-            lambda_coverage=model_opt.lambda_coverage,
-            lambda_align=model_opt.lambda_align,
+            lambda_coverage=model_opt.decoder.lambda_coverage,
+            lambda_align=model_opt.decoder.lambda_align,
+            vocabs=vocabs,
         )
         valid_loss.to(device)
-
         transforms_cls = get_transforms_cls(config._all_transform)
+        transforms_cls = make_transforms(config, transforms_cls, vocabs)
+
+        # if tgt is not precised in the inference config file, used from src
+        if config.tgt is None:
+            config.tgt = config.src
         infer_iter = build_dynamic_dataset_iter(
-            args,
-            transforms_cls,
-            vocabs,
-            task=CorpusTask.INFER,
-            device_id=config.gpu,
+            config, transforms_cls, vocabs, task=CorpusTask.INFER, device_id=device.index
         )
 
         model.to(device)
@@ -110,31 +107,36 @@ class LMScoring(BaseBin):
             src = batch["src"]
             src_len = batch["srclen"]
             # print(batch)
-            outputs, attns = model(src, None, src_len, with_align=False)
+            outputs, attns, _ = model(src, None, src_len, with_align=False)
             # Compute and retrieve the loss for EACH sentence
-            loss, _ = valid_loss(batch, outputs, attns)
+            loss, _, _ = valid_loss(batch, outputs, attns)
             loss = loss.view(batch_size, -1)  # (B, T)
-            losspertoken = loss.sum(1) / batch["tgt"][:, 1:, 0].ne(padding_idx).sum(1)
+            losspertoken = loss.sum(1) / batch["tgt"][:, 1:].ne(padding_idx).sum(1)
             ppl = torch.exp(losspertoken)
             cumul_loss += loss.sum().item()
-            cumul_length += batch["tgt"][:, 1:, 0].ne(padding_idx).sum().cpu()
+            cumul_length += batch["tgt"][:, 1:].ne(padding_idx).sum().cpu()
             # Now we need to rearrange the batch of ppl
             # in the original order with indices
             sent_ppl_orig = ppl.gather(
                 0,
                 torch.tensor(
-                    sorted(
-                        range(len(batch["cid_line_number"])),
-                        key=lambda k: batch["cid_line_number"][k],
-                    ),
+                    sorted(range(len(batch["cid_line_number"])), key=lambda k: batch["cid_line_number"][k]),
                     device=ppl.device,
                 ),
             )
             for j in range(batch_size):
                 ppl_file.write(str(sent_ppl_orig[j].item()) + "\n")
         logger.info(
-            "Loss: %.2f Tokens: %d Corpus PPL: %.2f" % (cumul_loss, cumul_length, np.exp(cumul_loss / cumul_length))
+            "Loss: %.2f Tokens: %d Corpus PPL: %.2f"
+            % (cumul_loss / cumul_length.item(), cumul_length, np.exp(cumul_loss / cumul_length))
         )
         ppl_file.close()
 
         os.system('paste "' + config.src + '" "' + config.output + '".ppl > "' + config.output + '"')
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    LMScoring.add_args(parser)
+    args = parser.parse_args()
+    LMScoring.run(args)

--- a/eole/bin/tools/LM_scoring.py
+++ b/eole/bin/tools/LM_scoring.py
@@ -61,7 +61,7 @@ class LMScoring(BaseBin):
         if len(config.gpu_ranks) > 1:
             logger.warning(f"gpu_ranks is {str(config.gpu_ranks)} but only the first one will be used.")
 
-        vocabs, model, model_opt = BaseModel.load_test_model(config, 0)
+        vocabs, model, model_opt = BaseModel.load_test_model(config, device.index)
         pad_token = vocabs["specials"].get("pad_token", DefaultTokens.PAD)
         padding_idx = vocabs["tgt"].tokens_to_ids[pad_token]
         criterion = torch.nn.CrossEntropyLoss(ignore_index=padding_idx, reduction="none")

--- a/eole/bin/tools/LM_scoring.py
+++ b/eole/bin/tools/LM_scoring.py
@@ -10,7 +10,6 @@ from eole.utils.loss import LossCompute
 from eole.constants import DefaultTokens, CorpusTask
 from eole.transforms import get_transforms_cls, make_transforms
 from eole.models.model import BaseModel
-from eole.decoders.ensemble import load_test_model as ensemble_load_test_model
 
 from argparse import ArgumentParser
 from eole.bin import BaseBin, register_bin
@@ -65,8 +64,7 @@ class LMScoring(BaseBin):
         if len(config.gpu_ranks) > 1:
             logger.warning(f"gpu_ranks is {str(config.gpu_ranks)} but only the first one will be used.")
 
-        load_test_model = ensemble_load_test_model if len(config.model_path) > 1 else BaseModel.load_test_model
-        vocabs, model, model_opt = load_test_model(config, 0)
+        vocabs, model, model_opt = BaseModel.load_test_model(config, 0)
         pad_token = vocabs["specials"].get("pad_token", DefaultTokens.PAD)
         padding_idx = vocabs["tgt"].tokens_to_ids[pad_token]
         criterion = torch.nn.CrossEntropyLoss(ignore_index=padding_idx, reduction="none")

--- a/eole/bin/tools/LM_scoring.py
+++ b/eole/bin/tools/LM_scoring.py
@@ -43,12 +43,7 @@ Corpus PPL is in the logger.info
 class LMScoring(BaseBin):
     @classmethod
     def add_args(cls, parser):
-        parser.add_argument(
-            "-config",
-            "--config",
-            "-c",
-            required=False,
-            help="Path of main YAML config file.")
+        parser.add_argument("-config", "--config", "-c", required=False, help="Path of main YAML config file.")
 
     @classmethod
     def run(cls, args):

--- a/eole/bin/tools/LM_scoring.py
+++ b/eole/bin/tools/LM_scoring.py
@@ -22,9 +22,6 @@ For this purpose we use the same pipeline as the validation of a file
 Below is an example of settings of a config.yaml file
 
 verbose: false
-n_best: 3
-top_p: 0.9
-beam_size: 10
 world_size: 1
 gpu_ranks: [0]
 # use symlinks to last saved step
@@ -126,10 +123,3 @@ class LMScoring(BaseBin):
         ppl_file.close()
 
         os.system('paste "' + config.src + '" "' + config.output + '".ppl > "' + config.output + '"')
-
-
-if __name__ == "__main__":
-    parser = ArgumentParser()
-    LMScoring.add_args(parser)
-    args = parser.parse_args()
-    LMScoring.run(args)


### PR DESCRIPTION
The LM_scoring.py script did not return any output when used in a stand-alone way (which is normal) but also there was an error when launching it the standard way
`python3 eole/eole/bin/main.py tools LM_scoring -config inference.yaml`
```
Traceback (most recent call last):
  File "/nas-labs/MT/pytorchwork/Recipes/toy-antoine/eole/eole/bin/main.py", line 38, in <module>
    main()
  File "/nas-labs/MT/pytorchwork/Recipes/toy-antoine/eole/eole/bin/main.py", line 34, in main
    bin_cls.run(args)
  File "/nas-labs/MT/pytorchwork/Recipes/toy-antoine/eole/eole/bin/tools/LM_scoring.py", line 68, in run
    config = PredictConfig(**config)
  File "/usr/local/lib/python3.10/dist-packages/pydantic/main.py", line 214, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 3 validation errors for PredictConfig
bin
  Extra inputs are not permitted [type=extra_forbidden, input_value='tools', input_type=str]
    For further information visit https://errors.pydantic.dev/2.10/v/extra_forbidden
sub_bin
  Extra inputs are not permitted [type=extra_forbidden, input_value='LM_scoring', input_type=str]
    For further information visit https://errors.pydantic.dev/2.10/v/extra_forbidden
config
  Extra inputs are not permitted [type=extra_forbidden, input_value='inference.yaml', input_type=str]
    For further information visit https://errors.pydantic.dev/2.10/v/extra_forbidden
```
(`config.update(stuff_to_update)` adds `{'bin': 'tools', 'sub_bin': 'LM_scoring', 'config': 'inference.yaml'}` which is not need for inference)
I removed the old code logic, every arguments lies in yaml config file now, the only arg needed is the config.

Moreover I adapted the loading of the model, which is now handled via `BaseModel.load_test_model(config, 0)`
and I also retrieve the corresponding unk token index using 
`padding_idx = vocabs["tgt"].tokens_to_ids[pad_token]`

Regarding the `CrossEntropyLoss` torch module initialization, it now requires a vocab, and `lambda_coverage` and `lambda_align` are now elsewhere in the config.

I also make sure transforms are correctly set-up and that `config.tgt` is duplicated from `config.src` if absent

There are light adaptations regarding loss computations, because it now returns `estims`.
An heavier adaptations is that the expected tensor format changed, we have now 2 dimensions instead of 3.

To print the loss, I now have to perform `cumul_loss / cumul_length.item()` instead of directly referring to `cumul_loss`

For my tests, I'm using a LM built with the wiki-103 recipe, I only changed training data (https://github.com/eole-nlp/eole/blob/main/recipes/wiki_103/wiki_103.yaml) and I observe differences regarding perplexities:
tensorboard: 20.9643 (3.0428 loss)
lm_scoring: 22.34 (3.11 loss)